### PR TITLE
Corrigindo a exibição do número e da média de avaliações

### DIFF
--- a/utils/formatRecipe.js
+++ b/utils/formatRecipe.js
@@ -1,7 +1,7 @@
-// Padronizar e melhorar o retorno na requisição das receitas
 import { formatPrepTime } from "./formatTime.js";
 
 export function formatRecipe(recipe) {
+  
   return {
     id: recipe.id,
     name: recipe.name,
@@ -17,5 +17,7 @@ export function formatRecipe(recipe) {
     image: recipe.image,
     user: recipe.user,
     likes: recipe._count?.favorites ?? 0,
+    ratingCount: recipe.ratingCount ?? 0,
+    ratingAvg: recipe.ratingAvg ?? null,
   };
 }


### PR DESCRIPTION
## ✨ Descrição

Este PR corrige a forma como as avaliações (ratings) são exibidas nas receitas.
Antes, o retorno não apresentava corretamente o número total de avaliações (`ratingCount`) e a média (`ratingAvg`), mesmo já existindo lógica para cálculo no serviço de Rating.

### Alterações realizadas

* Ajustado o `RecipeService` para incluir no retorno o **número de avaliações** e a **média calculada**.
* Atualizado o `formatRecipe` para exibir `ratingCount` e `ratingAvg` junto com os demais dados da receita.
* Garantido que o retorno mantenha consistência mesmo quando não houver avaliações (`ratingCount = 0`, `ratingAvg = null`).

### Impacto esperado

* O endpoint de receitas agora retorna corretamente as métricas de avaliação.
* Não há necessidade de alterar chamadas externas: a resposta segue o mesmo padrão já utilizado para likes.
* Melhora a consistência e confiabilidade dos dados exibidos ao usuário.